### PR TITLE
RA-1554: Fix OrderFrequency metadata deploy when in use by DrugOrder

### DIFF
--- a/api-1.10/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/OrderFrequencyDeployHandler.java
+++ b/api-1.10/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/OrderFrequencyDeployHandler.java
@@ -23,8 +23,12 @@ public class OrderFrequencyDeployHandler extends AbstractObjectDeployHandler<Ord
 
     @Override
     public OrderFrequency save(OrderFrequency obj) {
-        return orderService.saveOrderFrequency(obj);
-    }
+    	OrderFrequency existing = fetch(obj.getUuid());
+		if (existing == null) {
+			return orderService.saveOrderFrequency(obj);
+		}
+		return obj;
+	}
 
     @Override
     public void uninstall(OrderFrequency obj, String reason) {

--- a/api-1.10/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/OrderFrequencyDeployHandler.java
+++ b/api-1.10/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/OrderFrequencyDeployHandler.java
@@ -23,12 +23,12 @@ public class OrderFrequencyDeployHandler extends AbstractObjectDeployHandler<Ord
 
     @Override
     public OrderFrequency save(OrderFrequency obj) {
-    	OrderFrequency existing = fetch(obj.getUuid());
-		if (existing == null) {
-			return orderService.saveOrderFrequency(obj);
-		}
-		return obj;
-	}
+        OrderFrequency existing = fetch(obj.getUuid());
+        if (existing == null) {
+            return orderService.saveOrderFrequency(obj);
+        }
+        return obj;
+    }
 
     @Override
     public void uninstall(OrderFrequency obj, String reason) {


### PR DESCRIPTION
Fix OrderFrequency metadata deploy when in use by DrugOrder (Now we do not overide OrderFrequency entity if it already exists)

Jira ticket: https://issues.openmrs.org/browse/RA-1554