### PR TITLE
DPLY-40 Using DbSessionFactory and DbSession to bridge the Hibernate 3 vs. 4 differences

### DIFF
--- a/api-1.10/pom.xml
+++ b/api-1.10/pom.xml
@@ -18,7 +18,7 @@
         <MODULE_NAME>${project.parent.name}</MODULE_NAME>
         <MODULE_VERSION>${project.parent.version}</MODULE_VERSION>
         <MODULE_PACKAGE>${project.parent.groupId}.${project.parent.artifactId}</MODULE_PACKAGE>
-        <openMRSBuildVersion>1.10.0</openMRSBuildVersion>
+        <openMRSBuildVersion>1.10.2</openMRSBuildVersion>
     </properties>
 
     <dependencies>

--- a/api-1.10/pom.xml
+++ b/api-1.10/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>metadatadeploy</artifactId>
-        <version>1.8.1-SNAPSHOT</version>
+        <version>1.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metadatadeploy-api-1.10</artifactId>

--- a/api/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/PersonAttributeTypeDeployHandler.java
+++ b/api/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/PersonAttributeTypeDeployHandler.java
@@ -15,11 +15,10 @@
 package org.openmrs.module.metadatadeploy.handler.impl;
 
 import java.lang.reflect.Method;
-
-import org.hibernate.SessionFactory;
 import org.openmrs.PersonAttributeType;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.PersonService;
+import org.openmrs.api.db.hibernate.DbSessionFactory;
 import org.openmrs.module.metadatadeploy.handler.AbstractObjectDeployHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -35,7 +34,7 @@ public class PersonAttributeTypeDeployHandler extends AbstractObjectDeployHandle
 	private PersonService personService;
 
 	@Autowired
-	private SessionFactory sessionFactory;
+	private DbSessionFactory sessionFactory;
 
 	/**
 	 * @see org.openmrs.module.metadatadeploy.handler.ObjectDeployHandler#fetch(String)
@@ -80,14 +79,14 @@ public class PersonAttributeTypeDeployHandler extends AbstractObjectDeployHandle
 	 * 
 	 * @return the current hibernate session.
 	 */
-	private org.hibernate.Session getCurrentSession() {
+	private org.openmrs.api.db.hibernate.DbSession getCurrentSession() {
 		try {
 			return sessionFactory.getCurrentSession();
 		}
 		catch (NoSuchMethodError ex) {
 			try {
 				Method method = sessionFactory.getClass().getMethod("getCurrentSession", null);
-				return (org.hibernate.Session)method.invoke(sessionFactory, null);
+				return (org.openmrs.api.db.hibernate.DbSession)method.invoke(sessionFactory, null);
 			}
 			catch (Exception e) {
 				throw new RuntimeException("Failed to get the current hibernate session", e);

--- a/api/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/PersonAttributeTypeDeployHandler.java
+++ b/api/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/PersonAttributeTypeDeployHandler.java
@@ -79,14 +79,14 @@ public class PersonAttributeTypeDeployHandler extends AbstractObjectDeployHandle
 	 * 
 	 * @return the current hibernate session.
 	 */
-	private org.openmrs.api.db.hibernate.DbSession getCurrentSession() {
+	private  org.openmrs.api.db.hibernate.DbSession getCurrentSession() {
 		try {
 			return sessionFactory.getCurrentSession();
 		}
 		catch (NoSuchMethodError ex) {
 			try {
 				Method method = sessionFactory.getClass().getMethod("getCurrentSession", null);
-				return (org.openmrs.api.db.hibernate.DbSession)method.invoke(sessionFactory, null);
+				return ( org.openmrs.api.db.hibernate.DbSession)method.invoke(sessionFactory, null);
 			}
 			catch (Exception e) {
 				throw new RuntimeException("Failed to get the current hibernate session", e);

--- a/api/src/test/java/org/openmrs/module/metadatadeploy/handler/impl/RoleDeployHandlerTest.java
+++ b/api/src/test/java/org/openmrs/module/metadatadeploy/handler/impl/RoleDeployHandlerTest.java
@@ -15,12 +15,14 @@
 package org.openmrs.module.metadatadeploy.handler.impl;
 
 import org.hibernate.FlushMode;
+
 import org.hibernate.SessionFactory;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.Privilege;
 import org.openmrs.Role;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.db.hibernate.DbSessionFactory;
 import org.openmrs.module.metadatadeploy.MetadataUtils;
 import org.openmrs.module.metadatadeploy.api.MetadataDeployService;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
@@ -45,7 +47,7 @@ public class RoleDeployHandlerTest extends BaseModuleContextSensitiveTest {
 	private MetadataDeployService deployService;
 
 	@Autowired
-	private SessionFactory sessionFactory;
+	private DbSessionFactory sessionFactory;
 
 	/**
 	 * Tests use of handler for installation
@@ -152,14 +154,14 @@ public class RoleDeployHandlerTest extends BaseModuleContextSensitiveTest {
 	 * 
 	 * @return the current hibernate session.
 	 */
-	private org.hibernate.Session getCurrentSession() {
+	private org.openmrs.api.db.hibernate.DbSession getCurrentSession() {
 		try {
 			return sessionFactory.getCurrentSession();
 		}
 		catch (NoSuchMethodError ex) {
 			try {
 				Method method = sessionFactory.getClass().getMethod("getCurrentSession", null);
-				return (org.hibernate.Session)method.invoke(sessionFactory, null);
+				return (org.openmrs.api.db.hibernate.DbSession)method.invoke(sessionFactory, null);
 			}
 			catch (Exception e) {
 				throw new RuntimeException("Failed to get the current hibernate session", e);


### PR DESCRIPTION
For this,i am wondering on upgrading core,i successfully introduce DbSession and DbSessionFactory,but  but i run into The method setPrecise(boolean) is undefined for the type ConceptNumeric!!! this the ticket link  https://issues.openmrs.org/browse/DPLY-40?filter=-1   The orignal commit for this ticket were i made the changes is https://github.com/openmrs/openmrs-module-metadatadeploy/commit/53278ecc2150d896644396d0de03329db7a0ebd5