### PR TITLE
DPLY-40:Using DbSessionFactory and DbSession to bridge the Hibernate 3 vs. 4 differences

### DIFF
--- a/api-1.10/pom.xml
+++ b/api-1.10/pom.xml
@@ -18,7 +18,7 @@
         <MODULE_NAME>${project.parent.name}</MODULE_NAME>
         <MODULE_VERSION>${project.parent.version}</MODULE_VERSION>
         <MODULE_PACKAGE>${project.parent.groupId}.${project.parent.artifactId}</MODULE_PACKAGE>
-        <openMRSBuildVersion>1.10.0</openMRSBuildVersion>
+        <openMRSBuildVersion>1.10.2</openMRSBuildVersion>
     </properties>
 
     <dependencies>

--- a/api/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/PersonAttributeTypeDeployHandler.java
+++ b/api/src/main/java/org/openmrs/module/metadatadeploy/handler/impl/PersonAttributeTypeDeployHandler.java
@@ -14,12 +14,10 @@
 
 package org.openmrs.module.metadatadeploy.handler.impl;
 
-import java.lang.reflect.Method;
-
-import org.hibernate.SessionFactory;
 import org.openmrs.PersonAttributeType;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.PersonService;
+import org.openmrs.api.db.hibernate.DbSessionFactory;
 import org.openmrs.module.metadatadeploy.handler.AbstractObjectDeployHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -35,7 +33,7 @@ public class PersonAttributeTypeDeployHandler extends AbstractObjectDeployHandle
 	private PersonService personService;
 
 	@Autowired
-	private SessionFactory sessionFactory;
+	private DbSessionFactory sessionFactory;
 
 	/**
 	 * @see org.openmrs.module.metadatadeploy.handler.ObjectDeployHandler#fetch(String)
@@ -50,12 +48,14 @@ public class PersonAttributeTypeDeployHandler extends AbstractObjectDeployHandle
 	 */
 	@Override
 	public PersonAttributeType save(PersonAttributeType obj) {
-		// The regular save method in the person service does some interesting stuff to check name changes.. which breaks
-		// our way of replacing existing objects. Our workaround is to ask Hibernate directly to save the object
-		getCurrentSession().saveOrUpdate(obj);
+		// The regular save method in the person service does some interesting stuff to
+		// check name changes.. which breaks
+		// our way of replacing existing objects. Our workaround is to ask Hibernate
+		// directly to save the object
+		sessionFactory.getCurrentSession().saveOrUpdate(obj);
 		return obj;
 
-		//return personService.savePersonAttributeType(obj);
+		// return personService.savePersonAttributeType(obj);
 	}
 
 	/**
@@ -67,31 +67,21 @@ public class PersonAttributeTypeDeployHandler extends AbstractObjectDeployHandle
 	}
 
 	/**
-	 * @see org.openmrs.module.metadatadeploy.handler.ObjectDeployHandler#uninstall(org.openmrs.OpenmrsObject, String)
-	 * @param obj the object to uninstall
+	 * @see org.openmrs.module.metadatadeploy.handler.ObjectDeployHandler#uninstall(org.openmrs.OpenmrsObject,
+	 *      String)
+	 * @param obj
+	 *            the object to uninstall
 	 */
 	@Override
 	public void uninstall(PersonAttributeType obj, String reason) {
 		personService.retirePersonAttributeType(obj, reason);
 	}
-	
+
 	/**
-	 * Gets the current hibernate session while taking care of the hibernate 3 and 4 differences.
+	 * Gets the current hibernate session while taking care of the hibernate 3 and 4
+	 * differences.
 	 * 
 	 * @return the current hibernate session.
 	 */
-	private org.hibernate.Session getCurrentSession() {
-		try {
-			return sessionFactory.getCurrentSession();
-		}
-		catch (NoSuchMethodError ex) {
-			try {
-				Method method = sessionFactory.getClass().getMethod("getCurrentSession", null);
-				return (org.hibernate.Session)method.invoke(sessionFactory, null);
-			}
-			catch (Exception e) {
-				throw new RuntimeException("Failed to get the current hibernate session", e);
-			}
-		}
-	}
+
 }

--- a/api/src/test/java/org/openmrs/module/metadatadeploy/MetadataUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/metadatadeploy/MetadataUtilsTest.java
@@ -189,7 +189,7 @@ public class MetadataUtilsTest extends BaseModuleContextSensitiveTest {
 	@Test
 	public void getLocation_shouldFetchByUuid() {
 		Location unknown = Context.getLocationService().getLocation(1);
-		Assert.assertThat(MetadataUtils.getLocation("dc5c1fcc-0459-4201-bf70-0b90535ba362"), is(unknown));
+		Assert.assertThat(MetadataUtils.getLocation("8d6c993e-c2cc-11de-8d13-0010c6dffd0f"), is(unknown));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/module/metadatadeploy/handler/impl/RoleDeployHandlerTest.java
+++ b/api/src/test/java/org/openmrs/module/metadatadeploy/handler/impl/RoleDeployHandlerTest.java
@@ -15,12 +15,12 @@
 package org.openmrs.module.metadatadeploy.handler.impl;
 
 import org.hibernate.FlushMode;
-import org.hibernate.SessionFactory;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.Privilege;
 import org.openmrs.Role;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.db.hibernate.DbSessionFactory;
 import org.openmrs.module.metadatadeploy.MetadataUtils;
 import org.openmrs.module.metadatadeploy.api.MetadataDeployService;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
@@ -45,7 +45,7 @@ public class RoleDeployHandlerTest extends BaseModuleContextSensitiveTest {
 	private MetadataDeployService deployService;
 
 	@Autowired
-	private SessionFactory sessionFactory;
+	private DbSessionFactory sessionFactory;
 
 	/**
 	 * Tests use of handler for installation
@@ -106,7 +106,7 @@ public class RoleDeployHandlerTest extends BaseModuleContextSensitiveTest {
 	 */
 	@Test
 	public void integration_shouldWorkWithoutFlushes() {
-		getCurrentSession().setFlushMode(FlushMode.MANUAL);
+		sessionFactory.getCurrentSession().setFlushMode(FlushMode.MANUAL);
 
 		deployService.installObject(privilege("Privilege1", "Testing"));
 		deployService.installObject(role("Role1", "Testing", null, idSet("Privilege1")));
@@ -117,7 +117,7 @@ public class RoleDeployHandlerTest extends BaseModuleContextSensitiveTest {
 		deployService.installObject(role("Role1", "Testing", null, idSet("Privilege1")));
 
 		Context.flushSession();
-		getCurrentSession().setFlushMode(FlushMode.AUTO);
+		sessionFactory.getCurrentSession().setFlushMode(FlushMode.AUTO);
 	}
 
 	/**
@@ -152,18 +152,5 @@ public class RoleDeployHandlerTest extends BaseModuleContextSensitiveTest {
 	 * 
 	 * @return the current hibernate session.
 	 */
-	private org.hibernate.Session getCurrentSession() {
-		try {
-			return sessionFactory.getCurrentSession();
-		}
-		catch (NoSuchMethodError ex) {
-			try {
-				Method method = sessionFactory.getClass().getMethod("getCurrentSession", null);
-				return (org.hibernate.Session)method.invoke(sessionFactory, null);
-			}
-			catch (Exception e) {
-				throw new RuntimeException("Failed to get the current hibernate session", e);
-			}
-		}
-	}
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 	</modules>
 	
 	<properties>
-		<openMRSVersion>1.9.4</openMRSVersion>
-		<openMRSBuildVersion>1.9.4</openMRSBuildVersion>
+		<openMRSVersion>1.9.9</openMRSVersion>
+		<openMRSBuildVersion>1.9.9</openMRSBuildVersion>
 
 		<!-- Module dependencies -->
 		<metadatasharingVersion>1.1.8</metadatasharingVersion>


### PR DESCRIPTION
For this ticket,https://issues.openmrs.org/browse/DPLY-40  i introduced DbSession and DbSessionFactory  in PersonAttributeTypeDeployHandler and RoleDeployHandlerTest by upgrading core to 1.9.9 in pom.xml as required.I had also to upgrade core to 1.10.2 in api-1.10/pom.xml so as to make DbSession and DbSessionFactory available for the tests in OrderFrequencyDeployHandlerTest.I also changed the uuid in MetadataUtilsTest for the tests to pass.