### PR TITLE
Fixed the SNAPSHOT version to 1.13.1

### DIFF
--- a/api-1.10/pom.xml
+++ b/api-1.10/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>metadatadeploy</artifactId>
-        <version>1.8.1-SNAPSHOT</version>
+        <version>1.13.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>metadatadeploy-api-1.10</artifactId>

--- a/api-1.11/pom.xml
+++ b/api-1.11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>metadatadeploy</artifactId>
-        <version>1.8.1-SNAPSHOT</version>
+        <version>1.13.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>metadatadeploy-api-1.11</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>metadatadeploy</artifactId>
-		<version>1.8.1-SNAPSHOT</version>
+		<version>1.13.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metadatadeploy-api</artifactId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>metadatadeploy</artifactId>
-		<version>1.8.1-SNAPSHOT</version>
+		<version>1.13.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>metadatadeploy-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>metadatadeploy</artifactId>
-	<version>1.8.1-SNAPSHOT</version>
+	<version>1.13.1-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 	<name>Metadata Deploy</name>


### PR DESCRIPTION
Description of what I did:
I changed the SNAPSHOT version from `1.8.1-SNAPSHOT - 1.13.1-SNAPSHOT`  basing on the discussion on this Talk post https://talk.openmrs.org/t/proposal-for-limited-scope-refapp-2-13-request-for-release-manager/37824/47